### PR TITLE
修复UID、PID已经存在时，无法启动的问题。

### DIFF
--- a/app/run.sh
+++ b/app/run.sh
@@ -144,4 +144,4 @@ then
 fi
 
 # 启动aria2
-sudo -u "$USER" /usr/bin/aria2c --conf-path=/conf/aria2.conf
+sudo -u#${PUID} /usr/bin/aria2c --conf-path=/conf/aria2.conf


### PR DESCRIPTION
改用UID启动进程。fix #10