### PR TITLE
change: use low level utility for adding users and groups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,11 @@ RUN apk add --no-cache \
     sudo \
     nginx \
     curl \
-    tzdata 
+    tzdata \
+    shadow
+    
+RUN groupadd -o -g 1000 aria2 \
+    && useradd -o -g 1000 -u 1000 aria2
 
 RUN ARIAGN_VERSION=`curl --silent "https://api.github.com/repos/mayswind/AriaNg/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'` \
     && mkdir -p /run/nginx \

--- a/app/run.sh
+++ b/app/run.sh
@@ -125,13 +125,8 @@ then
     USER=root
 else
     USER=aria2
-    addgroup --gid "$PGID" "$USER"
-    adduser \
-        --disabled-password \
-        --ingroup "$USER" \
-        --no-create-home \
-        --uid "$PUID" \
-        "$USER"
+    groupmod -o -g "$PGID" "$USER"
+    usermod -o -u "$PUID" -g "$PGID" "$USER"
 fi
 
 # 启动nginx


### PR DESCRIPTION
### 问题
1. 首次启动，如果设置的 GID 被占用，启动时创建用户组失败，会导致 接下来的创建用户失败，最终启动失败
2. 更换 UID 和 GID 后启动，存在同样的创建用户和组失败问题

### 修改：
1. 容器创建时创建默认账户，确保账户存在
2. 启动时根据 ENV 修改用户和组的 ID